### PR TITLE
chore: backend Dockerization, Makefile enhancements, and health check endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,8 @@ docker-up:
 docker-down:
 	docker compose down -v
 
+docker-up-all:
+	docker compose up --build -d
+
 reset-db:
 	docker-down docker-up migrate-force migrate-up

--- a/README.md
+++ b/README.md
@@ -1,10 +1,111 @@
 # do-it-now
+
 A focus-enforcing task app that locks your phone until you complete your checklist. Built with Go, SwiftUI, Docker, and AWS.
 
-## Overview
+---
 
-Do It Now is a focus-enforcing task app that locks your phone until you complete your checklist.  
-Backend is written in Go, with a SwiftUI iOS frontend.
+## Local Development Setup
+
+### Prerequisites
+
+- [Go](https://golang.org/doc/install) (v1.21+)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [Make](https://www.gnu.org/software/make/)
+
+---
+
+### 1. Clone the Repository
+
+```
+git clone https://github.com/yourusername/do-it-now.git
+cd do-it-now
+```
+
+---
+
+### 2. Environment Variables
+
+- Copy `.env.example` to `.env` and update as needed.
+- The default `DB_URL` is set for local Docker Compose usage.
+
+---
+
+### 3. Running the Stack
+
+Build and start the backend API and Postgres database using Docker Compose via Makefile:
+
+```
+make docker-up-all
+```
+
+- This will build and start all services in the background.
+
+Check container status:
+
+```
+docker compose ps
+```
+
+---
+
+### 4. Database Migrations
+
+Apply migrations to your local Postgres DB:
+
+```
+make migrate-up
+```
+
+Rollback the last migration:
+
+```
+make migrate-down-one
+```
+
+---
+
+### 5. Health Check
+
+Test that your backend API is running:
+
+```
+curl http://localhost:8080/healthz
+```
+
+You should see:
+
+```
+ok
+```
+
+---
+
+### 6. Stopping the Stack
+
+To stop and remove all containers and volumes:
+
+```
+make docker-down
+```
+
+---
+
+### 7. Troubleshooting
+
+- **Backend build errors:** Ensure `go.mod` and `go.sum` exist in `backend/`. Run `go mod tidy` if needed.
+- **No Go files in /app:** Make sure your main Go entrypoint is in `backend/cmd/main.go` and your Dockerfile uses `RUN go build ... ./cmd`.
+- **Database connection issues:** Ensure `DB_URL` uses `db` as the hostname (not `localhost`).
+- **Port conflicts:** Make sure port 8080 is free or update the port mapping in `docker-compose.yml` and your Go app.
+
+---
+
+### 8. Makefile Commands Reference
+
+- `make docker-up-all` — Build and start all services (API + DB)
+- `make docker-down` — Stop and remove all services and volumes
+- `make migrate-up` — Apply all migrations
+- `make migrate-down-one` — Rollback the last migration
+- `make db-shell` — Open a psql shell to the database
 
 ---
 
@@ -25,10 +126,9 @@ Copy `.env.example` to `.env` and update values as needed.
 
 | Variable      | Description                        | Required | Default | Example Value                                         |
 |---------------|------------------------------------|----------|---------|-------------------------------------------------------|
-| DB_URL        | Postgres connection string         | Yes      | —       | postgres://user:password@localhost:5432/doitnow?sslmode=disable |
+| DB_URL        | Postgres connection string         | Yes      | —       | postgres://user:password@db:5432/doitnow?sslmode=disable |
 | SERVER_PORT   | HTTP server port                   | Yes      | —       | 8080                                                  |
 | LOG_LEVEL     | Logging level (`info`, `debug`)    | No       | info    | info                                                  |
-
 
 **Never commit real secrets.**  
 Update `.env.example` if you add new config fields.
@@ -41,10 +141,10 @@ Update `.env.example` if you add new config fields.
    - Do **not** commit `.env` (it is gitignored).
    - Update `.env.example` if you add new config fields.
    
-2. Start services with Docker Compose:
+2. Start services with Docker Compose via Makefile:
 
-   ```sh
-   docker-compose up --build
+   ```
+   make docker-up-all
    ```
 
 3. The API will be available at `http://localhost:8080`.
@@ -58,13 +158,13 @@ All database schema changes are managed via SQL migrations in [`backend/migratio
 We use [golang-migrate/migrate](https://github.com/golang-migrate/migrate) for applying migrations.
 
 - To apply migrations:  
-  ```sh
-  migrate -path ./backend/migrations -database "$DB_URL" up
-   ```
+  ```
+  make migrate-up
+  ```
 - To create a new migration:
-  ```sh
-   migrate create -ext sql -dir ./backend/migrations -seq <migration_name>   
-   ```
+  ```
+  migrate create -ext sql -dir ./backend/migrations -seq <migration_name>
+  ```
 
 See [`backend/migrations/README.md`](backend/migrations/README.md) for full instructions and best practices.
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+# filepath: /Users/nmpotential/workspaces/go/src/github.com/nmpotential/do-it-now/backend/Dockerfile
+# Build stage
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o doitnow -ldflags="-s -w" ./cmd
+
+# Run stage
+FROM alpine:latest
+
+WORKDIR /app
+COPY --from=builder /app/doitnow .
+COPY migrations ./migrations
+
+EXPOSE 8080
+
+CMD ["./doitnow"]

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,5 +1,19 @@
 package main
 
+import (
+	"log"
+	"net/http"
+)
+
+// A simple web server with a health check endpoint
 func main() {
-	// TODO: Wire up config, logger, router, and start the server.
+	// Health check endpoint
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Health check endpoint hit")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	// Start the server
+	log.Println("Starting server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:17.6
@@ -17,6 +15,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  api:
+    build: ./backend
+    ports:
+      - "8080:8080"
+    environment:
+      DB_URL: postgres://user:password@db:5432/doitnow?sslmode=disable
+    depends_on:
+      - db
 
 volumes:
   pgdata:


### PR DESCRIPTION
- Adds a multi-stage Dockerfile for the Go backend, supporting builds from /cmd
- Updates Makefile with docker-up-all for building and running the full stack
- Ensures backend and Postgres run together via Docker Compose
- Implements a minimal /healthz endpoint for container health checks
- Updates README with new setup, usage, and troubleshooting instructions
- Adds troubleshooting for common Docker and Go build issues